### PR TITLE
Allow set column types

### DIFF
--- a/xlsxwriter.class.php
+++ b/xlsxwriter.class.php
@@ -221,6 +221,13 @@ class XLSXWriter
 		return $column_types;
 	}
 
+	public function setColumnTypes($sheet_name, array $header_types): void
+	{
+		$this->initializeSheet($sheet_name);
+		$sheet = &$this->sheets[$sheet_name];
+		$sheet->columns = $this->initializeColumnTypes($header_types);
+	}
+
 	public function writeSheetHeader($sheet_name, array $header_types, $col_options = null): void
     {
 		if (empty($sheet_name) || empty($header_types) || !empty($this->sheets[$sheet_name]))


### PR DESCRIPTION
Allow set column types after `writeSheetRow()`.
```php
  $xlsxFile = new XLSXWriter();
  $addHeader = true;
  while (($data = fgetcsv($csvFile, null, ';')) !== false) {
    if ($addHeader) {
      // optionaly set cols and sheet options
      $xlsxFile->writeSheetHeader('Sheet1', [], ['suppress_row' => true]);
      // add header row with custom style
      $xlsxFile->writeSheetRow('Sheet1', $data, ['wrap_text' => true, 'height' => 40]);
      // set format for data under header
      $xlsxFile->setColumnTypes('Sheet1', ['string', 'integer', 'string', 'datetime']);
      $addHeader = false;
      continue;
    }
    $xlsxFile->writeSheetRow('Sheet1', $data);
  }
```